### PR TITLE
fix aws_lambda_function_event_invoke_config unexpected format for function resource

### DIFF
--- a/aws/resource_aws_lambda_function_event_invoke_config.go
+++ b/aws/resource_aws_lambda_function_event_invoke_config.go
@@ -289,7 +289,7 @@ func resourceAwsLambdaFunctionEventInvokeConfigParseId(id string) (string, strin
 			return id, "", nil
 		}
 
-		functionParts := strings.Split(id, ":")
+		functionParts := strings.Split(function, ":")
 
 		if len(functionParts) != 2 || functionParts[0] == "" || functionParts[1] == "" {
 			return "", "", fmt.Errorf("unexpected format of function resource (%s), expected name:qualifier", id)


### PR DESCRIPTION
functionParts := strings.Split(id, ":") -> id is the arn and the length of variable functionParts was always greater then 2 hence if case was always true.
modified it to functionParts := strings.Split(function, ":") -> length of variable functionParts will either be 1 or 2 based on if user provides qualifier or not.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
